### PR TITLE
[patch-axel-14] boot: remove explicit MODE_RESERVED

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -25,7 +25,7 @@ typedef cte_t *slot_ptr_t;
 typedef struct ndks_boot {
     p_region_t reserved[MAX_NUM_RESV_REG];
     word_t resv_count;
-    region_t   freemem[MAX_NUM_FREEMEM_REG];
+    p_region_t freemem[MAX_NUM_FREEMEM_REG];
     seL4_BootInfo      *bi_frame;
     seL4_SlotPos slot_pos_cur;
 } ndks_boot_t;

--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -42,7 +42,7 @@ static inline bool_t is_reg_empty(region_t reg)
 p_region_t get_p_reg_kernel_img_boot(void);
 p_region_t get_p_reg_kernel_img(void);
 bool_t init_freemem(word_t n_available, const p_region_t *available,
-                    word_t n_reserved, const region_t *reserved,
+                    word_t n_reserved, const p_region_t *reserved,
                     v_region_t it_v_reg, word_t extra_bi_size_bits);
 bool_t reserve_region(p_region_t reg);
 void write_slot(slot_ptr_t slot_ptr, cap_t cap);

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -24,7 +24,7 @@
 #include <plat/machine/intel-vtd.h>
 
 #define MAX_RESERVED 1
-BOOT_BSS static region_t reserved[MAX_RESERVED];
+BOOT_BSS static p_region_t reserved[MAX_RESERVED];
 
 /* functions exactly corresponding to abstract specification */
 
@@ -72,11 +72,14 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
                                           mem_p_regs_t *mem_p_regs,
                                           word_t extra_bi_size_bits)
 {
-    // Extend the reserved region down to include the base of the kernel image.
-    // KERNEL_ELF_PADDR_BASE is the lowest physical load address used
-    // in the x86 linker script.
-    ui_p_reg.start = KERNEL_ELF_PADDR_BASE;
-    reserved[0] = paddr_to_pptr_reg(ui_p_reg);
+    /* The reserved region is not only the user image, but starts at the base of
+     * the kernel image. KERNEL_ELF_PADDR_BASE is the lowest physical load
+     * address used in the x86 linker script.
+     */
+    reserved[0] = (p_region_t) {
+        .start = KERNEL_ELF_PADDR_BASE,
+        .end   = ui_p_reg.end
+    };
     return init_freemem(mem_p_regs->count, mem_p_regs->list, MAX_RESERVED,
                         reserved, it_v_reg, extra_bi_size_bits);
 }

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -852,7 +852,7 @@ BOOT_CODE static word_t check_available_memory(word_t n_available,
     }
 
     word_t cnt = 0;
-    printf("available phys memory regions: %"SEL4_PRIu_word"\n", n_available);
+    printf("Available phys memory regions: %"SEL4_PRIu_word"\n", n_available);
     /* Force ordering and exclusivity of available regions. */
     for (word_t i = 0; i < n_available; i++) {
         const p_region_t *r = &available[i];
@@ -933,7 +933,7 @@ BOOT_CODE static word_t check_available_memory(word_t n_available,
 BOOT_CODE static bool_t check_reserved_memory(word_t n_reserved,
                                               const region_t *reserved)
 {
-    printf("reserved virt address space regions: %"SEL4_PRIu_word"\n",
+    printf("Reserved virt address space regions: %"SEL4_PRIu_word"\n",
            n_reserved);
     /* Force ordering and exclusivity of reserved regions. */
     for (word_t i = 0; i < n_reserved; i++) {

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -43,6 +43,11 @@ BOOT_CODE p_region_t get_p_reg_kernel_img(void)
     };
 }
 
+BOOT_CODE static bool_t is_p_reg_empty(p_region_t p_reg)
+{
+    return p_reg.start == p_reg.end;
+}
+
 BOOT_CODE static void merge_regions(void)
 {
     /* Walk through reserved regions and see if any can be merged */
@@ -67,7 +72,7 @@ BOOT_CODE bool_t reserve_region(p_region_t reg)
 {
     word_t i;
     assert(reg.start <= reg.end);
-    if (reg.start == reg.end) {
+    if (is_p_reg_empty(reg)) {
         return true;
     }
 
@@ -124,9 +129,9 @@ BOOT_CODE static bool_t insert_region(region_t reg)
     }
 
     for (word_t i = 0; i < ARRAY_SIZE(ndks_boot.freemem); i++) {
-        if (is_reg_empty(ndks_boot.freemem[i])) {
-            reserve_region(pptr_to_paddr_reg(reg));
-            ndks_boot.freemem[i] = reg;
+        if (is_p_reg_empty(ndks_boot.freemem[i])) {
+            ndks_boot.freemem[i] = pptr_to_paddr_reg(reg);
+            reserve_region(ndks_boot.freemem[i]);
             return true;
         }
     }
@@ -814,8 +819,8 @@ BOOT_CODE bool_t create_untypeds(cap_t root_cnode_cap)
 
     /* convert remaining freemem into UT objects and provide the caps */
     for (word_t i = 0; i < ARRAY_SIZE(ndks_boot.freemem); i++) {
-        region_t reg = ndks_boot.freemem[i];
-        ndks_boot.freemem[i] = REG_EMPTY;
+        region_t reg = paddr_to_pptr_reg(ndks_boot.freemem[i]);
+        ndks_boot.freemem[i] = P_REG_EMPTY;
         if (!create_untypeds_for_region(root_cnode_cap, false, reg, first_untyped_slot)) {
             printf("ERROR: creation of untypeds for free memory region #%u at"
                    " [%"SEL4_PRIx_word"..%"SEL4_PRIx_word"] failed\n",
@@ -981,7 +986,7 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
     }
 
     for (word_t i = 0; i < ARRAY_SIZE(ndks_boot.freemem); i++) {
-        ndks_boot.freemem[i] = REG_EMPTY;
+        ndks_boot.freemem[i] = P_REG_EMPTY;
     }
 
     word_t a = 0;
@@ -1043,13 +1048,13 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
 
     /* now try to fit the root server objects into a region */
     int i = ARRAY_SIZE(ndks_boot.freemem) - 1;
-    if (!is_reg_empty(ndks_boot.freemem[i])) {
+    if (!is_p_reg_empty(ndks_boot.freemem[i])) {
         printf("ERROR: insufficient MAX_NUM_FREEMEM_REG (%u)\n",
                (unsigned int)MAX_NUM_FREEMEM_REG);
         return false;
     }
     /* skip any empty regions */
-    for (; i >= 0 && is_reg_empty(ndks_boot.freemem[i]); i--);
+    for (; i >= 0 && is_p_reg_empty(ndks_boot.freemem[i]); i--);
 
     /* try to grab the last available p region to create the root server objects
      * from. If possible, retain any left over memory as an extra p region */
@@ -1061,7 +1066,7 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
         /* Invariant; the region at index i is the current candidate.
          * Invariant: regions 0 up to (i - 1), if any, are additional candidates.
          * Invariant: region (i + 1) is empty. */
-        assert(is_reg_empty(ndks_boot.freemem[i + 1]));
+        assert(is_p_reg_empty(ndks_boot.freemem[i + 1]));
         /* Invariant: regions above (i + 1), if any, are empty or too small to use.
          * Invariant: all non-empty regions are ordered, disjoint and unallocated. */
 
@@ -1070,22 +1075,26 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
          * indices that are sums of variables and small constants. */
         int empty_index = i + 1;
 
-        /* Try to take the top-most suitably sized and aligned chunk. */
-        pptr_t unaligned_start = ndks_boot.freemem[i].end - size;
+        /* Try to take the top-most suitably sized and aligned chunk. Convert
+         * to a region in the kernel window for the alignment checks.
+         */
+        region_t free_reg = paddr_to_pptr_reg(ndks_boot.freemem[i]);
+        pptr_t unaligned_start = free_reg.end - size;
         pptr_t start = ROUND_DOWN(unaligned_start, max);
         /* if unaligned_start didn't underflow, and start fits in the region,
          * then we've found a region that fits the root server objects. */
-        if (unaligned_start <= ndks_boot.freemem[i].end
-            && start >= ndks_boot.freemem[i].start) {
+        if ((unaligned_start <= free_reg.end) && (start >= free_reg.start)) {
             create_rootserver_objects(start, it_v_reg, extra_bi_size_bits);
             /* There may be leftovers before and after the memory we used. */
+            word_t p_start = ndks_boot.freemem[i].start + (start - free_reg.start);
+            assert(ndks_boot.freemem[i].end >= p_start + size);
             /* Shuffle the after leftover up to the empty slot (i + 1). */
-            ndks_boot.freemem[empty_index] = (region_t) {
-                .start = start + size,
+            ndks_boot.freemem[empty_index] = (p_region_t) {
+                .start = p_start + size,
                 .end = ndks_boot.freemem[i].end
             };
             /* Leave the before leftover in current slot i. */
-            ndks_boot.freemem[i].end = start;
+            ndks_boot.freemem[i].end = p_start;
             /* Regions i and (i + 1) are now well defined, ordered, disjoint,
              * and unallocated, so we can return successfully. */
             return true;
@@ -1095,7 +1104,7 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
         ndks_boot.freemem[empty_index] = ndks_boot.freemem[i];
         /* Now region i is unused, so make it empty to reestablish the invariant
          * for the next iteration (when it will be slot i + 1). */
-        ndks_boot.freemem[i] = REG_EMPTY;
+        ndks_boot.freemem[i] = P_REG_EMPTY;
     }
 
     /* We didn't find a big enough region. */

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -769,10 +769,11 @@ BOOT_CODE bool_t create_untypeds(cap_t root_cnode_cap)
 
     paddr_t start = 0;
     for (word_t i = 0; i < ndks_boot.resv_count; i++) {
-        if (start < ndks_boot.reserved[i].start) {
+        paddr_t reg_start = ndks_boot.reserved[i].start;
+        if (start < reg_start) {
             region_t reg = paddr_to_pptr_reg((p_region_t) {
                 .start = start,
-                .endd = ndks_boot.reserved[i].start
+                .end = reg_start
             });
             if (!create_untypeds_for_region(root_cnode_cap, true, reg, first_untyped_slot)) {
                 printf("ERROR: creation of untypeds for device region #%u at"

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -771,7 +771,8 @@ BOOT_CODE bool_t create_untypeds(cap_t root_cnode_cap)
     for (word_t i = 0; i < ndks_boot.resv_count; i++) {
         if (start < ndks_boot.reserved[i].start) {
             region_t reg = paddr_to_pptr_reg((p_region_t) {
-                start, ndks_boot.reserved[i].start
+                .start = start,
+                .endd = ndks_boot.reserved[i].start
             });
             if (!create_untypeds_for_region(root_cnode_cap, true, reg, first_untyped_slot)) {
                 printf("ERROR: creation of untypeds for device region #%u at"
@@ -786,7 +787,8 @@ BOOT_CODE bool_t create_untypeds(cap_t root_cnode_cap)
 
     if (start < CONFIG_PADDR_USER_DEVICE_TOP) {
         region_t reg = paddr_to_pptr_reg((p_region_t) {
-            start, CONFIG_PADDR_USER_DEVICE_TOP
+            .start = start,
+            .end = CONFIG_PADDR_USER_DEVICE_TOP
         });
 
         if (!create_untypeds_for_region(root_cnode_cap, true, reg, first_untyped_slot)) {

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -121,16 +121,16 @@ BOOT_CODE bool_t reserve_region(p_region_t reg)
     return true;
 }
 
-BOOT_CODE static bool_t insert_region(region_t reg)
+BOOT_CODE static bool_t insert_region(p_region_t reg)
 {
     assert(reg.start <= reg.end);
-    if (is_reg_empty(reg)) {
+    if (is_p_reg_empty(reg)) {
         return true;
     }
 
     for (word_t i = 0; i < ARRAY_SIZE(ndks_boot.freemem); i++) {
         if (is_p_reg_empty(ndks_boot.freemem[i])) {
-            ndks_boot.freemem[i] = pptr_to_paddr_reg(reg);
+            ndks_boot.freemem[i] = reg;
             reserve_region(ndks_boot.freemem[i]);
             return true;
         }
@@ -939,13 +939,13 @@ BOOT_CODE static word_t check_available_memory(word_t n_available,
 
 
 BOOT_CODE static bool_t check_reserved_memory(word_t n_reserved,
-                                              const region_t *reserved)
+                                              const p_region_t *reserved)
 {
     printf("Reserved virt address space regions: %"SEL4_PRIu_word"\n",
            n_reserved);
     /* Force ordering and exclusivity of reserved regions. */
     for (word_t i = 0; i < n_reserved; i++) {
-        const region_t *r = &reserved[i];
+        const p_region_t *r = &reserved[i];
         printf("  [%"SEL4_PRIx_word"..%"SEL4_PRIx_word"]\n", r->start, r->end);
 
         /* Reserved regions must be sane, the size is allowed to be zero. */
@@ -970,7 +970,7 @@ BOOT_CODE static bool_t check_reserved_memory(word_t n_reserved,
  * A region represents an area of memory.
  */
 BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
-                              word_t n_reserved, const region_t *reserved,
+                              word_t n_reserved, const p_region_t *reserved,
                               v_region_t it_v_reg, word_t extra_bi_size_bits)
 {
     /* Check the available memory region and initialize avail_reg to hold the
@@ -985,15 +985,18 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
         return false;
     }
 
+    /* Ensure ndks_boot.freemem is properly initialized. */
     for (word_t i = 0; i < ARRAY_SIZE(ndks_boot.freemem); i++) {
         ndks_boot.freemem[i] = P_REG_EMPTY;
     }
 
     word_t a = 0;
     word_t r = 0;
-    /* Now iterate through the available regions, removing any reserved regions. */
+    /* Now iterate through the available regions. Populate ndks_boot.freemem
+     * and ndks_boot.reserved
+     */
     while (a < n_available && r < n_reserved) {
-        if (reserved[r].start == reserved[r].end) {
+        if (is_p_reg_empty(reserved[r])) {
             /* reserved region is empty - skip it */
             r++;
         } else if (avail_reg[a].start >= avail_reg[a].end) {
@@ -1001,7 +1004,7 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
             a++;
         } else if (reserved[r].end <= avail_reg[a].start) {
             /* the reserved region is below the available region - skip it */
-            reserve_region(pptr_to_paddr_reg(reserved[r]));
+            reserve_region(reserved[r]);
             r++;
         } else if (reserved[r].start >= avail_reg[a].end) {
             /* the reserved region is above the available region - take the whole thing */
@@ -1013,18 +1016,18 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
                 /* the region overlaps with the start of the available region.
                  * trim start of the available region */
                 avail_reg[a].start = MIN(avail_reg[a].end, reserved[r].end);
-                reserve_region(pptr_to_paddr_reg(reserved[r]));
+                reserve_region(reserved[r]);
                 r++;
             } else {
                 assert(reserved[r].start < avail_reg[a].end);
                 /* take the first chunk of the available region and move
                  * the start to the end of the reserved region */
-                region_t m = avail_reg[a];
+                p_region_t m = avail_reg[a];
                 m.end = reserved[r].start;
                 insert_region(m);
                 if (avail_reg[a].end > reserved[r].end) {
                     avail_reg[a].start = reserved[r].end;
-                    reserve_region(pptr_to_paddr_reg(reserved[r]));
+                    reserve_region(reserved[r]);
                     r++;
                 } else {
                     a++;
@@ -1035,7 +1038,7 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
 
     for (; r < n_reserved; r++) {
         if (reserved[r].start < reserved[r].end) {
-            reserve_region(pptr_to_paddr_reg(reserved[r]));
+            reserve_region(reserved[r]);
         }
     }
 


### PR DESCRIPTION
On AARCH32 there is a special need for an ASID region. Since no other architecture needs this mechanism, handle this within the AARCH32 specific code and keep the generic code clean.