### PR TITLE
[patch-axel-48] cleanup and align IPI definitions

### DIFF
--- a/include/arch/arm/arch/32/mode/machine.h
+++ b/include/arch/arm/arch/32/mode/machine.h
@@ -75,14 +75,6 @@
 #define CNT_CVAL CNTV_CVAL
 #endif
 
-#ifdef ENABLE_SMP_SUPPORT
-/* Use the first two SGI (Software Generated Interrupt) IDs
- * for seL4 IPI implementation. SGIs are per-core banked.
- */
-#define irq_remote_call_ipi        0
-#define irq_reschedule_ipi         1
-#endif /* ENABLE_SMP_SUPPORT */
-
 word_t PURE getRestartPC(tcb_t *thread);
 void setNextPC(tcb_t *thread, word_t v);
 

--- a/include/arch/arm/arch/64/mode/machine.h
+++ b/include/arch/arm/arch/64/mode/machine.h
@@ -35,14 +35,6 @@
 #endif
 #define CNTFRQ   "cntfrq_el0"
 
-#ifdef ENABLE_SMP_SUPPORT
-/* Use the first two SGI (Software Generated Interrupt) IDs
- * for seL4 IPI implementation. SGIs are per-core banked.
- */
-#define irq_remote_call_ipi        0
-#define irq_reschedule_ipi         1
-#endif /* ENABLE_SMP_SUPPORT */
-
 word_t PURE getRestartPC(tcb_t *thread);
 void setNextPC(tcb_t *thread, word_t v);
 

--- a/include/arch/arm/arch/machine/gic_common.h
+++ b/include/arch/arm/arch/machine/gic_common.h
@@ -15,18 +15,35 @@
 #define GICD_SGIR_CPUTARGETLIST_SHIFT     16
 #define GICD_SGIR_TARGETLISTFILTER_SHIFT  24
 
-/* Special IRQ's */
-#define SPECIAL_IRQ_START 1020u
-#define IRQ_NONE          1023u
+enum {
+    /*
+     * The ARM GIC reserves interrupt 0-15 for SGIs (Software Generated
+     * Interrupt) and 16-31 for PPIs (Private Peripheral Interrupt). Both SGIs
+     * and PPIs are banked per core. Interrupt 32 and above are SPIs (Shared
+     * Peripheral Interrupt), which are global.
+     */
+    gic_irq_sgi_start               = 0,
+#ifdef ENABLE_SMP_SUPPORT
+    /* Use the first two SGIs for the IPI implementation */
+    gic_irq_remote_call_ipi         = 0,
+    gic_irq_reschedule_ipi          = 1,
+#endif /* ENABLE_SMP_SUPPORT */
+    gic_irq_ppi_start               = 16,
+    gic_irq_spi_start               = 32,
+    gic_irq_special_start           = 1020,
+    gic_irq_none                    = 1023,
+    gic_irq_invalid                 = (word_t)(-1)
+} gic_interrupts_t;
 
-/* CPU specific IRQ's */
-#define SGI_START         0u
-#define PPI_START         16u
+#define SGI_START         ((word_t)gic_irq_sgi_start)
+#define PPI_START         ((word_t)gic_irq_ppi_start)
+#define SPI_START         ((word_t)gic_irq_spi_start)
+#define SPECIAL_IRQ_START ((word_t)gic_irq_special_start)
+#define IRQ_NONE          ((word_t)gic_irq_none)
 
-/* Shared Peripheral Interrupts */
-#define SPI_START         32u
+/* ToDo: There is a CONFIG_NUM_PPI also, that is not sync'd with this define */
+#define NUM_PPI           SPI_START
 
-#define NUM_PPI SPI_START
 #define HW_IRQ_IS_SGI(irq) ((irq) < PPI_START)
 #define HW_IRQ_IS_PPI(irq) ((irq) < NUM_PPI)
 
@@ -51,11 +68,11 @@
                         CORE_IRQ_TO_IRQT(0, (idx) - (CONFIG_MAX_NUM_NODES-1)*NUM_PPI))
 #define IRQT_TO_CORE(irqt) (irqt.target_core)
 #define IRQT_TO_IRQ(irqt) (irqt.irq)
-irq_t irqInvalid = CORE_IRQ_TO_IRQT(-1, -1);
+irq_t irqInvalid = CORE_IRQ_TO_IRQT(-1, gic_irq_invalid);
 
 #else
 #define IRQ_IS_PPI(irq) HW_IRQ_IS_PPI(irq)
-irq_t irqInvalid = (uint16_t) -1;
+irq_t irqInvalid = gic_irq_invalid;
 #endif
 
 /* Setters/getters helpers for hardware irqs */

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -276,8 +276,6 @@ void initIRQController(void);
 void setIRQTrigger(irq_t irq, bool_t trigger);
 
 #ifdef ENABLE_SMP_SUPPORT
-#define irq_remote_call_ipi     (INTERRUPT_IPI_0)
-#define irq_reschedule_ipi      (INTERRUPT_IPI_1)
 
 static inline void arch_pause(void)
 {

--- a/src/arch/riscv/platform_gen.h.in
+++ b/src/arch/riscv/platform_gen.h.in
@@ -30,8 +30,8 @@ enum IRQConstants {
     PLIC_IRQ_OFFSET = 0,
     PLIC_MAX_IRQ = PLIC_IRQ_OFFSET + (@CONFIGURE_MAX_IRQ@),
 #ifdef ENABLE_SMP_SUPPORT
-    INTERRUPT_IPI_0,
-    INTERRUPT_IPI_1,
+    irq_remote_call_ipi,
+    irq_reschedule_ipi,
 #endif
     KERNEL_TIMER_IRQ,
     maxIRQ = KERNEL_TIMER_IRQ,


### PR DESCRIPTION
remove alias names and indirection, do it like it is done on x86